### PR TITLE
Issue MPS-29 has been resolved, convenorships can be added/removed

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -753,7 +753,7 @@ class FacultyData(db.Model):
         :return:
         """
 
-        flash('Installed {name} as convenor of {title}'.format(name=self.name, title=pclass.name))
+        flash('Installed {name} as convenor of {title}'.format(name=self.user.name, title=pclass.name))
 
 
     def remove_convenorship(self, pclass):
@@ -785,7 +785,7 @@ class FacultyData(db.Model):
 
         db.session.commit()
 
-        flash('Removed {name} as convenor of {title}'.format(name=self.name, title=pclass.name))
+        flash('Removed {name} as convenor of {title}'.format(name=self.user.name, title=pclass.name))
 
 
     @property


### PR DESCRIPTION
* A change to the FacultyData class resulted in the 'name' attribute being moved to 'user.name'.
* This had not been reflected in the add_convenorship and remove_convenorship methods.
* As far as I can tell, this issue is not present anywhere else in the code (but who knows 😛)