### PR TITLE
Remove kubenetes.io/ingress.class annotation

### DIFF
--- a/Deployments/kubenetes/k8s-manifests/ingress-default.yml
+++ b/Deployments/kubenetes/k8s-manifests/ingress-default.yml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   name: ingress-default
   annotations:
-    kubenetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
The annotation is a legacy construct and not required for NGINX Ingress.