### PR TITLE
Change K8s manifest runAsUser from 500 to 1000

### DIFF
--- a/Deployments/kubenetes/k8s-manifests/deploy-app.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-app.yml
@@ -95,7 +95,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 500
+            runAsUser: 1000
           volumeMounts:
             # would not be used in a production cluster, instead the object store would be a S3 or GCS bucket
             - mountPath: /object_storage

--- a/Deployments/kubenetes/k8s-manifests/deploy-celery-dashboard.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-celery-dashboard.yml
@@ -78,7 +78,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 500
+            runAsUser: 1000
           volumeMounts:
             # would not be used in a production cluster, instead the object store would be a S3 or GCS bucket
             - mountPath: /object_storage

--- a/Deployments/kubenetes/k8s-manifests/deploy-celery-scheduler.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-celery-scheduler.yml
@@ -90,7 +90,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 500
+            runAsUser: 1000
           volumeMounts:
             # would not be used in a production cluster, instead the object store would be a S3 or GCS bucket
             - mountPath: /object_storage

--- a/Deployments/kubenetes/k8s-manifests/deploy-default-worker.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-default-worker.yml
@@ -96,7 +96,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 500
+            runAsUser: 1000
           volumeMounts:
             # would not be used in a production cluster, instead the object store would be a S3 or GCS bucket
             - mountPath: /object_storage

--- a/Deployments/kubenetes/k8s-manifests/deploy-priority-worker.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-priority-worker.yml
@@ -96,7 +96,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 500
+            runAsUser: 1000
           volumeMounts:
             # would not be used in a production cluster, instead the object store would be a S3 or GCS bucket
             - mountPath: /object_storage


### PR DESCRIPTION
By default, Linux systems automatically assign UIDs and GIDs to new user accounts in numerical order starting at 1000.

The theory behind this arbitrary assignment is that anything below 1000 is reserved for system accounts, services, and other special accounts, and regular user UIDs and GIDs stay above 1000.