### PR TITLE
Remove DATABASE_ROOT_PASSWORD env var from Kubernetes deployment

### DIFF
--- a/Deployments/kubenetes/k8s-manifests/deploy-app.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-app.yml
@@ -40,12 +40,6 @@ spec:
               value: redis://$(REDIS_HOSTNAME):6379
             - name: RATELIMIT_REDIS_URI
               value: redis://$(REDIS_HOSTNAME):6379
-            # root password needed for backups; consider whether there is some alternative approach
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/kubenetes/k8s-manifests/deploy-celery-dashboard.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-celery-dashboard.yml
@@ -37,12 +37,6 @@ spec:
               value: redis://$(REDIS_HOSTNAME):6379
             - name: RATELIMIT_REDIS_URI
               value: redis://$(REDIS_HOSTNAME):6379
-            # root password needed for backups; consider whether there is some alternative approach
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/kubenetes/k8s-manifests/deploy-celery-scheduler.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-celery-scheduler.yml
@@ -37,12 +37,6 @@ spec:
               value: redis://$(REDIS_HOSTNAME):6379
             - name: RATELIMIT_REDIS_URI
               value: redis://$(REDIS_HOSTNAME):6379
-            # root password needed for backups; consider whether there is some alternative approach
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/kubenetes/k8s-manifests/deploy-default-worker.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-default-worker.yml
@@ -39,12 +39,6 @@ spec:
               value: redis://$(REDIS_HOSTNAME):6379
             - name: RATELIMIT_REDIS_URI
               value: redis://$(REDIS_HOSTNAME):6379
-            # root password needed for backups; consider whether there is some alternative approach
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/kubenetes/k8s-manifests/deploy-priority-worker.yml
+++ b/Deployments/kubenetes/k8s-manifests/deploy-priority-worker.yml
@@ -39,12 +39,6 @@ spec:
               value: redis://$(REDIS_HOSTNAME):6379
             - name: RATELIMIT_REDIS_URI
               value: redis://$(REDIS_HOSTNAME):6379
-            # root password needed for backups; consider whether there is some alternative approach
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-app.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-app.yml
@@ -42,11 +42,6 @@ spec:
                 secretKeyRef:
                   name: enginfprojects-mongodb-credentials
                   key: root_password
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: enginfprojects-mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-dashboard.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-dashboard.yml
@@ -38,11 +38,6 @@ spec:
                 secretKeyRef:
                   name: enginfprojects-mongodb-credentials
                   key: root_password
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: enginfprojects-mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-scheduler.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-scheduler.yml
@@ -38,11 +38,6 @@ spec:
                 secretKeyRef:
                   name: enginfprojects-mongodb-credentials
                   key: root_password
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: enginfprojects-mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-default-worker.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-default-worker.yml
@@ -43,11 +43,6 @@ spec:
                 secretKeyRef:
                   name: enginfprojects-mongodb-credentials
                   key: root_password
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: enginfprojects-mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-priority-worker.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-priority-worker.yml
@@ -43,11 +43,6 @@ spec:
                 secretKeyRef:
                   name: enginfprojects-mongodb-credentials
                   key: root_password
-            - name: DATABASE_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: enginfprojects-mariadb-credentials
-                  key: root_password
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
No longer required in the image 2023.2.9