### PR TITLE
Add backup for assets and backup buckets

### DIFF
--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/backup-role.yaml
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/backup-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: suex-enginfprojects-prod
+  name: backup-enginfprojects-prod
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/backup-rolebinding.yaml
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/backup-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: suex-enginfprojects-prod
+  name: backup-enginfprojects-prod
+subjects:
+- kind: ServiceAccount
+  name: backup-enginfprojects-prod
+roleRef:
+  kind: Role
+  name: backup-enginfprojects-prod
+  apiGroup: rbac.authorization.k8s.io

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/backup-sa.yaml
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/backup-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: suex-enginfprojects-prod
+  name: backup-enginfprojects-prod

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/cronjob-assets.yaml
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/cronjob-assets.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-enginfprojects-assets-prod
+  namespace: suex-enginfprojects-prod
+spec:
+  schedule: "30 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: backup-enginfprojects-prod
+          volumes:
+          - name: script
+            configMap:
+              name: backup-enginfprojects-prod-script
+              defaultMode: 0777
+          containers:
+          - command: ["/bin/bash"]
+            args: ["-c", "/script/backup.sh"]
+            image: ghcr.io/zugao/mc-kubectl:v0.0.1
+            name: enginfprojects-assets-prod
+            envFrom:
+            - secretRef:
+                name: enginfprojects-assets-prod-credentials
+            volumeMounts:
+            - mountPath: /script
+              name: script
+          restartPolicy: Never
+      backoffLimit: 0

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/cronjob-backup.yaml
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/cronjob-backup.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-enginfprojects-backup-prod
+  namespace: suex-enginfprojects-prod
+spec:
+  schedule: "30 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: backup-enginfprojects-prod
+          volumes:
+          - name: script
+            configMap:
+              name: backup-enginfprojects-prod-script
+              defaultMode: 0777
+          containers:
+          - command: ["/bin/bash"]
+            args: ["-c", "/script/backup.sh"]
+            image: ghcr.io/zugao/mc-kubectl:v0.0.1
+            name: enginfprojects-backup-prod
+            envFrom:
+            - secretRef:
+                name: enginfprojects-backup-prod-credentials
+            volumeMounts:
+            - mountPath: /script
+              name: script
+          restartPolicy: Never
+      backoffLimit: 0

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/script-cm.yaml
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/script-cm.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backup-enginfprojects-prod-script
+  namespace: suex-enginfprojects-prod
+data:
+  backup.sh: |
+    set -e
+
+    # Check if Source Secret is loaded
+    [[ -z "${ENDPOINT_URL}" ]] && echo "ENDPOINT_URL is not set!" && exit 1
+    [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && echo "AWS_SECRET_ACCESS_KEY is not set!" && exit 1
+    [[ -z "${AWS_ACCESS_KEY_ID}" ]] && echo "AWS_ACCESS_KEY_ID is not set!" && exit 1
+    [[ -z "${BUCKET_NAME}" ]] && echo "BUCKET_NAME is not set!" && exit 1
+
+    # Set the destination Bucket based on the day
+    DESTINATION_BUCKET="backup-${BUCKET_NAME}-$(date +%d)"
+    DESTINATION_SECRET="${DESTINATION_BUCKET}-credentials"
+    DESTINATION_URL=$(echo -n $(kubectl get secrets ${DESTINATION_SECRET} -o=jsonpath='{.data.ENDPOINT_URL}') | base64 -d)
+    DESTINATION_ACCESSKEY=$(echo -n $(kubectl get secrets ${DESTINATION_SECRET} -o=jsonpath='{.data.AWS_ACCESS_KEY_ID}') | base64 -d)
+    DESTINATION_SECRETKEY=$(echo -n $(kubectl get secrets ${DESTINATION_SECRET}  -o=jsonpath='{.data.AWS_SECRET_ACCESS_KEY}') | base64 -d)
+
+    # Configure Source and Destination Bucket for minio cli
+    mc --config-dir /tmp/ alias set source ${ENDPOINT_URL} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY} --api S3v4
+    mc --config-dir /tmp/ alias set destination ${DESTINATION_URL} ${DESTINATION_ACCESSKEY} ${DESTINATION_SECRETKEY} --api S3v4
+
+    # check if source bucket exists
+    mc -q --config-dir /tmp/ ls source/${BUCKET_NAME} || ( echo "Bucket ${BUCKET_NAME} does not exists!" && exit 1)
+
+    # check if destination bucket exists
+    mc -q --config-dir /tmp/ ls destination/${DESTINATION_BUCKET} || ( echo "Bucket ${DESTINATION_BUCKET} does not exists!" && exit 1)
+
+    # Mirror source bucket into the destination bucket
+    echo "Mirror ${BUCKET_NAME} bucket to ${DESTINATION_BUCKET} bucket"
+    mc --config-dir /tmp/ mirror source/${BUCKET_NAME} destination/${DESTINATION_BUCKET} --overwrite --remove

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/util/Dockerfile
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/util/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+	install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+ENTRYPOINT ["/bin/bash"]

--- a/Deployments/suex-enginfprojects-prod/manual-manifests/backup/util/bucket-creation.sh
+++ b/Deployments/suex-enginfprojects-prod/manual-manifests/backup/util/bucket-creation.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script creates backup buckets on Exoscale in ch-dk-2 zone
+# in <namespace> with <prefix name> and <amount> of buckets
+# Usage: ./bucket-creation.sh <prefix name> <namespace> <amount>
+
+set -e
+
+PREFIX_NAME=$1
+NAMESPACE=$2
+DAYS=$3
+
+for (( i = 1; i <= DAYS; i++ )); do
+   echo $i
+   DESTINATION_BUCKET="backup-${PREFIX_NAME}-$i";
+   echo "Creating bucket " $DESTINATION_BUCKET
+   kubectl apply --as cluster-admin -f - <<EOF
+      apiVersion: appcat.vshn.io/v1
+      kind: ObjectBucket
+      metadata:
+        name: $DESTINATION_BUCKET
+        namespace: $NAMESPACE
+      spec:
+        parameters:
+          bucketName: $DESTINATION_BUCKET
+          region: ch-dk-2
+        writeConnectionSecretToRef:
+          name: $DESTINATION_BUCKET-credentials
+EOF
+done


### PR DESCRIPTION
This PR adds backup solution to `enginfprojects-assets-prod` and `enginfprojects-backup-prod`.It will run a backup each day at 01:30 am for a whole month. 

The image mc-kubectl has been pushed under my github account as I lack permission to push into ds283 account. This has to be updated.

This PR will be merged as soon as object bucket deletion protection is implemented.



