### PR TITLE
Ajust CPU and memory limits and set a limit

### DIFF
--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-app.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-app.yml
@@ -22,10 +22,11 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
+              cpu: 250m
               memory: 384Mi
             requests:
-              cpu: 100m
-              memory: 256Mi         
+              cpu: 25m
+              memory: 256Mi
           ports:
             - containerPort: 5000
           envFrom:

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-dashboard.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-dashboard.yml
@@ -21,9 +21,12 @@ spec:
           imagePullPolicy: Always
           command: ["./launch_flower.sh"]
           resources:
-            requests:
+            limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
+            requests:
+              cpu: 25m
+              memory: 384Mi
           envFrom:
             - configMapRef:
                 name: enginfprojects-environment

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-scheduler.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-celery-scheduler.yml
@@ -21,9 +21,12 @@ spec:
           imagePullPolicy: Always
           command: ["./launch_beat.sh"]
           resources:
-            requests:
+            limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
+            requests:
+              cpu: 25m
+              memory: 384Mi
           envFrom:
             - configMapRef:
                 name: enginfprojects-environment

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-default-worker.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-default-worker.yml
@@ -23,10 +23,11 @@ spec:
           command: ["./launch_celery.sh"]
           resources:
             limits:
-              memory: 2Gi
+              cpu: 500m
+              memory: 1280Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              cpu: 100m
+              memory: 1024Mi
           envFrom:
             - configMapRef:
                 name: enginfprojects-environment

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-priority-worker.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/deploy-priority-worker.yml
@@ -23,10 +23,11 @@ spec:
           command: ["./launch_celery.sh"]
           resources:
             limits:
-              memory: 2Gi
+              cpu: 500m
+              memory: 1280Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              cpu: 100m
+              memory: 1024Mi
           envFrom:
             - configMapRef:
                 name: enginfprojects-environment


### PR DESCRIPTION
APPUiO Cloud does set a CPU limit if not defined. So it's better to manage this explicitly.

Adjusted the resources to measured values on APPUiO Cloud.

Ref: https://docs.appuio.cloud/user/references/default-quota.html#_checking_the_quota_and_limit_values