### PR TITLE
Increase HorizontalPodAutoscaler averageUtilization to 80%

### DIFF
--- a/Deployments/suex-enginfprojects-test/k8s-manifests/autoscale-app.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/autoscale-app.yml
@@ -16,4 +16,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 80

--- a/Deployments/suex-enginfprojects-test/k8s-manifests/autoscale-default-worker.yml
+++ b/Deployments/suex-enginfprojects-test/k8s-manifests/autoscale-default-worker.yml
@@ -16,4 +16,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 80


### PR DESCRIPTION
The HorizontalPodAutoscaler should start later to increase the pod amount, because it's generally better to saturate the existing pods, rather to increase the overhead on the node CPU scheduler.